### PR TITLE
Add Express Entry results by topic help page

### DIFF
--- a/eric/hc/hc_redictpilot/results-by-topic.html
+++ b/eric/hc/hc_redictpilot/results-by-topic.html
@@ -1,0 +1,335 @@
+<!doctype html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" dir="ltr" lang="en" xmlns="http://www.w3.org/1999/xhtml"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js" dir="ltr" lang="en" xmlns="http://www.w3.org/1999/xhtml"><!--<![endif]-->
+<head>
+<meta charset="utf-8">
+<title>Express Entry</title>
+<meta content="width=device-width,initial-scale=1" name="viewport">
+<meta name="description" content="Results by topic - Express Entry">
+<meta property="dcterms.creator" content="Government of Canada; Immigration, Refugees and Citizenship Canada">
+<meta property="dcterms:title" content="Express Entry">
+<meta property="dcterms:issued" title="W3CDTF" content="2012-11-07">
+<meta property="dcterms:modified" title="W3CDTF" content="2025-12-05">
+<meta property="dcterms:subject" title="scheme" content="Immigration; Visitor Visas; Foreign Workers; Work Permits; Family Sponsorship; Foreign Students; Study Permits; Permanent Residence; Citizenship; International Adoption; Refugees; Refugee Protection;">
+<meta property="dcterms:language" title="ISO639-2" content="eng">
+<meta property="dcterms:service" content="IRCC">
+<meta property="dcterms:accessRights" content="2">
+<link rel="alternate" hreflang="fr" href="https://ircc.canada.ca/francais/centre-aide/resultats-par-sujet.asp?top=29">
+<link href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
+<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
+<noscript><link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" /></noscript>
+</head>
+<body vocab="http://schema.org/" resource="#wb-webpage" typeof="WebPage">
+<nav>
+  <ul id="wb-tphp">
+    <li class="wb-slc"><a class="wb-sl" href="#wb-cont">Skip to main content</a></li>
+    <li class="wb-slc"><a class="wb-sl" href="#wb-info">Skip to "About government"</a></li>
+  </ul>
+</nav>
+<header>
+  <div id="wb-bnr" class="container">
+    <div class="row">
+      <section id="wb-lng" class="col-xs-3 col-sm-12 pull-right text-right">
+        <h2 class="wb-inv">Language selection</h2>
+        <ul class="list-inline mrgn-bttm-0">
+          <li><a lang="fr" hreflang="fr" href="https://ircc.canada.ca/francais/centre-aide/resultats-par-sujet.asp?top=29"><span class="hidden-xs">Fran&ccedil;ais</span><abbr title="Fran&ccedil;ais" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">fr</abbr></a></li>
+        </ul>
+      </section>
+      <div class="brand col-xs-9 col-sm-5 col-md-4" property="publisher" resource="#wb-publisher" typeof="GovernmentOrganization">
+        <a href="https://www.canada.ca/en.html" property="url"><img src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="Government of Canada" property="logo"><span class="wb-inv"> / <span lang="fr">Gouvernement du Canada</span></span></a>
+        <meta property="name" content="Government of Canada">
+        <meta property="areaServed" typeof="Country" content="Canada">
+        <link property="logo" href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg">
+      </div>
+      <section id="wb-srch" class="col-lg-offset-4 col-md-offset-4 col-sm-offset-2 col-xs-12 col-sm-5 col-md-4">
+        <h2>Search</h2>
+        <form action="https://www.canada.ca/en/services/immigration-citizenship/search.html" method="get" name="cse-search-box" role="search">
+          <div class="form-group wb-srch-qry">
+            <label for="wb-srch-q" class="wb-inv">Search IRCC</label>
+            <input name="cdn" value="canada" type="hidden">
+            <input name="st" value="s" type="hidden">
+            <input name="num" value="10" type="hidden">
+            <input name="langs" value="en" type="hidden">
+            <input name="st1rt" value="1" type="hidden">
+            <input name="s5bm3ts21rch" value="x" type="hidden">
+            <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Search IRCC">
+            <input type="hidden" name="_charset_" value="UTF-8">
+            <datalist id="wb-srch-q-ac"></datalist>
+          </div>
+          <div class="form-group submit">
+            <button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
+          </div>
+        </form>
+      </section>
+    </div>
+  </div>
+  <nav class="gcweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+    <div class="container">
+      <h2 class="wb-inv">Menu</h2>
+      <button type="button" aria-haspopup="true" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+      <ul role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
+      </ul>
+    </div>
+  </nav>
+  <nav id="wb-bc" property="breadcrumb">
+    <h2>You are here:</h2>
+    <div class="container">
+      <ol class="breadcrumb">
+        <li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>
+        <li><a href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
+        <li><a href="https://ircc.canada.ca/english/helpcentre/index.asp">Help Centre</a></li>
+        <li><a href="https://ircc.canada.ca/english/helpcentre/index-a-z-can.asp">All topics</a></li>
+        <li><a href="https://ircc.canada.ca/english/helpcentre/results-by-topic.asp?top=29">Express Entry</a></li>
+      </ol>
+    </div>
+  </nav>
+</header>
+<main property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+  <span class="wb-toggle" data-toggle='{"selector": "main summary", "print": "on"}'></span>
+  <header class="jumbotron mrgn-bttm-0">
+    <div class="container text-center">
+      <a href="https://ircc.canada.ca/english/helpcentre/index.asp"><img src="https://ircc.canada.ca/english/helpcentre/images/title_withicon.png" class="img-responsive center-block mrgn-bttm-md" alt="Help Centre what do you need help with?"></a>
+      <form id="searchForm" class="mrgn-bttm-xl form-inline" action="https://www.canada.ca/en/services/immigration-citizenship/helpcentre/search.html" method="get" role="form">
+        <div class="form-group">
+          <label for="sch-inp-ac" class="h3 mrgn-tp-sm wb-inv">What do you need help with?<br></label>
+          <div class="inputs">
+            <input name="_charset_" value="UTF-8" type="hidden">
+            <input id="sch-inp-ac" class="form-control pull-left mrgn-rght-sm" name="q" type="search" size="87" value="" list="suggestions" autocomplete="on" dir="ltr" spellcheck="false">
+            <input class="btn btn-primary" id="sch-inp" name="wb-srch-sub" type="submit" value="Search">
+          </div>
+        </div>
+      </form>
+    </div>
+  </header>
+  <section class="container">
+    <h1 id="wb-cont" property="name">Express Entry</h1>
+    <script type="text/javascript">
+document.write('<div class="pull-right"><a href="https://ircc.canada.ca/english/helpcentre/questions-answers-by-topic.asp?top=29" class="btn btn-default"><span class="glyphicon glyphicon-print"></span> View and print all answers for this topic</a></div>');
+</script>
+    <div class="clearfix"></div>
+    <div class="clearfix">
+                <!-- 29.9 -->
+                <details>
+                <summary>General questions about Express Entry</summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1325&amp;top=29">When I try to submit my Express Entry profile or my application, I get an error. What can I do?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1140&amp;top=29">Can I ask to only be considered for one of the programs under Express Entry?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1338&amp;top=29">I am in the Express Entry pool. How do I find out what programs I am eligible for?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1359&amp;top=29">I'm in the Express Entry pool. How can I look for a job in Canada?</a></li>
+                </ul>
+                </details>
+                <!-- 29.1 -->
+                <details>
+                <summary>Filling out your profile</summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=864&amp;top=29">Can I have more than one Express Entry profile?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1067&amp;top=29">In my online profile or application I am getting validation errors or it tells me that fields are incomplete when they are not. What do I do?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=992&amp;top=29">The online tool said I was eligible for Express Entry, but my completed profile says I'm not. Which one is right?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=993&amp;top=29">Can I use my existing Job Bank account to get matched with employers for Express Entry?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=995&amp;top=29">My personal reference code is not working. What should I do?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=997&amp;top=29">I am a native English or French speaker. Why do I need to take a language test for Express Entry?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=999&amp;top=29">A message in my account says my profile was updated. I didn't update it today (or don't see an update). What happened?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1000&amp;top=29">I accidently withdrew my Express Entry profile. How can I fix this?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1001&amp;top=29">I was found not eligible for Express Entry and I can't change my profile. What do I do?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1002&amp;top=29">How do I update my Express Entry profile before submitting it?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1003&amp;top=29">Some fields in my Express Entry profile are greyed out and I can't change them. How do I update them?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1004&amp;top=29">How do I confirm that my Express Entry profile is complete?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1005&amp;top=29">I already submitted my Express Entry profile. Can I still update it?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1006&amp;top=29">Where can I find my Express Entry profile number and/or Job Seeker validation code?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1076&amp;top=29">How do I withdraw my Express Entry profile?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1125&amp;top=29">In an Express Entry profile, should I only include the minimum work experience needed to qualify for one of the programs, or should I include more?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1127&amp;top=29">In an Express Entry profile, what do you mean by the "date the applicant first became qualified to practise this occupation?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1128&amp;top=29">How do I fill out my Express Entry profile when I have maintained my status?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1129&amp;top=29">How do I get education points for Express Entry if I have 2 or more degrees or diplomas?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1164&amp;top=29">If my Express Entry profile expires, will the system keep my information?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1294&amp;top=29">Can I be eligible for more than one program under Express Entry?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1260&amp;top=29">Can I be invited to apply if I've lost my username or password?</a></li>
+                </ul>
+                </details>
+                <!-- 29.2 -->
+                <details>
+                <summary>Work experience and job offers</summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1012&amp;top=29">There is no National Occupation Classification (NOC) code on my work permit. What should I put in my Express Entry profile?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=394&amp;top=29">Can I count student work experience toward the Express Entry work requirement?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1132&amp;top=29">I have been working in Canada for the last 6 months but didn't get points for work experience. Why not?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1134&amp;top=29">What if I am invited to apply for Express Entry while waiting for a new work permit?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1135&amp;top=29">I was invited to apply through Express Entry but my work permit expired. What do I do?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1136&amp;top=29">I didn't get a Job Seeker Validation Code in the message you sent to my account. Why not?</a></li>
+                </ul>
+                </details>
+                <!-- 29.3 -->
+                <details>
+                <summary>Applying online and technical help</summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=829&amp;top=29">What is a personal document checklist?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=830&amp;top=29">What is a personal reference code?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=1137&amp;top=29">How do I upload more supporting documents after I have already submitted my online application for permanent residence through Express Entry?</a></li>
+                </ul>
+                </details>
+                <!-- 29.4 -->
+                <details>
+                <summary>Federal skilled workers</summary>
+                <div class="mgrn-lft-md">
+                <!-- 29.4.1 -->
+                <details>
+                <summary><strong class="small">Applying - General</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=696&amp;top=29">The employer I work for temporarily in Canada wants to offer me a full-time job. Will I need a new LMIA for Express Entry?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=698&amp;top=29">I am working in Canada on a post-graduation work permit. Do I need a Labour Market Impact Assessment?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=867&amp;top=29">Can I re-use my Educational Credential Assessment (ECA) report to submit my Express Entry profile?</a></li>
+                </ul>
+                </details>
+                <!-- 29.4.2 -->
+                <details>
+                <summary><strong class="small">Language testing</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=638&amp;top=29">Do I need a language test to immigrate to Canada?</a></li>
+                </ul>
+                </details>
+                <!-- 29.4.4 -->
+                <details>
+                <summary><strong class="small">Having your education assessed</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=683&amp;top=29">Does an Educational Credential Assessment (ECA) mean that I can be licensed in a regulated profession?</a></li>
+                </ul>
+                </details>
+                </div>
+                </details>
+                <!-- 29.5 -->
+                <details>
+                <summary>Canadian Experience Class</summary>
+                <div class="mgrn-lft-md">
+                <!-- 29.5.1 -->
+                <details>
+                <summary><strong class="small">Applying - General</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=675&amp;top=29">Can I complete an Express Entry profile before I have a year of work experience?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=382&amp;top=29">Can I apply under the Canadian Experience Class if I am currently living in Quebec and I plan to live elsewhere in Canada?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=676&amp;top=29">Can I renew my post-graduation work permit?</a></li>
+                </ul>
+                </details>
+                <!-- 29.5.2 -->
+                <details>
+                <summary><strong class="small">Determining your eligibility</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=389&amp;top=29">Can I still be eligible for Canadian Experience Class if I have returned to my country?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=667&amp;top=29">I graduated a while ago, then earned one-year of work experience and now I am back in school. Can I apply for permanent residence under the Canadian Experience Class?</a></li>
+                </ul>
+                </details>
+                <!-- 29.5.3 -->
+                <details>
+                <summary><strong class="small">Work Experience</strong></summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=387&amp;top=29">Can I count experience I got in Canada while waiting for a decision on my refugee application?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=663&amp;top=29">While working under a post-graduate work permit to get experience to qualify for the Canadian Experience Class, can I switch employers?</a></li>
+                </ul>
+                </details>
+                </div>
+                </details>
+                <!-- 29.7 -->
+                <details>
+                <summary>Skilled trades</summary>
+                <ul>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=745&amp;top=29">How can I qualify for the Federal Skilled Trades Program if the province or territory where I plan to live and work does not give Certificates of Qualification in my trade?</a></li>
+                <li><a href="https://ircc.canada.ca/english/helpcentre/answer.asp?qnum=747&amp;top=29">If I come to Canada under the Federal Skilled Trades Program, will I be qualified to work in any province or territory?</a></li>
+                </ul>
+                </details>
+    <!-- CONTENT ENDS | FIN DU CONTENU -->
+    </div>
+  </section>
+  <div class="pagedetails container">
+    <div class="row">
+      <div class="col-sm-6 col-md-5 col-lg-4"></div>
+    </div>
+    <dl id="wb-dtmd">
+      <dt>Date modified: </dt>
+      <dd><time property="dateModified">2025-12-05</time></dd>
+    </dl>
+  </div>
+</main>
+<footer id="wb-info">
+  <h2 class="wb-inv">About this site</h2>
+  <div class="gc-contextual">
+    <div class="container">
+      <nav>
+        <h3>Immigration and citizenship</h3>
+        <ul class="list-col-xs-1 list-col-sm-2 list-col-md-3">
+          <li><a href="https://ircc.canada.ca/english/helpcentre/index-featured-can.asp">Help Centre</a></li>
+          <li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/corporate/contact-ircc.html">Contact us</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <div class="gc-main-footer">
+    <div class="container">
+      <nav>
+        <h3>Government of Canada</h3>
+        <ul class="list-col-xs-1 list-col-sm-2 list-col-md-3">
+          <li><a href="https://www.canada.ca/en/contact.html">All contacts</a></li>
+          <li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
+          <li><a href="https://www.canada.ca/en/government/system.html">About government</a></li>
+        </ul>
+        <h4><span class="wb-inv">Themes and topics</span></h4>
+        <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+          <li><a href="https://www.canada.ca/en/services/jobs.html">Jobs</a></li>
+          <li><a href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
+          <li><a href="https://travel.gc.ca/">Travel and tourism</a></li>
+          <li><a href="https://www.canada.ca/en/services/business.html">Business</a></li>
+          <li><a href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
+          <li><a href="https://www.canada.ca/en/services/health.html">Health</a></li>
+          <li><a href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
+          <li><a href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
+          <li><a href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+          <li><a href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+          <li><a href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
+          <li><a href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
+          <li><a href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
+          <li><a href="https://www.canada.ca/en/services/finance.html">Money and finance</a></li>
+          <li><a href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
+          <li><a href="https://www.canada.ca/en/services/indigenous-peoples.html">Indigenous peoples</a></li>
+          <li><a href="https://www.canada.ca/en/services/veterans-military.html">Veterans and military</a></li>
+          <li><a href="https://www.canada.ca/en/services/youth.html">Youth</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <div class="gc-sub-footer">
+    <div class="container d-flex align-items-center">
+      <nav>
+        <h3 class="wb-inv">Government of Canada Corporate</h3>
+        <ul>
+          <li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
+          <li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
+          <li><a href="https://www.canada.ca/en/government/about-canada-ca.html">About Canada.ca</a></li>
+          <li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
+          <li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+        </ul>
+      </nav>
+      <div class="wtrmrk align-self-end">
+        <img src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+<script src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a new help center page for Express Entry that organizes frequently asked questions by topic, allowing users to easily find answers to common questions about the Express Entry immigration program.

## Changes
- **New file**: `eric/hc/hc_redictpilot/results-by-topic.html`
  - Complete HTML page following Government of Canada web standards (GCWeb theme)
  - Implements a collapsible accordion-style layout using HTML5 `<details>` and `<summary>` elements
  - Organizes Express Entry FAQs into 7 main topic categories:
    - General questions about Express Entry
    - Filling out your profile
    - Work experience and job offers
    - Applying online and technical help
    - Federal skilled workers (with nested subtopics)
    - Canadian Experience Class (with nested subtopics)
    - Skilled trades
  - Includes proper metadata, accessibility features, language selection (English/French), and navigation elements
  - Integrates with IRCC Help Centre search functionality and site navigation

## Notable Details
- Uses semantic HTML with proper ARIA attributes for accessibility
- Follows Government of Canada web standards and design patterns
- Includes bilingual support with French language alternate link
- Contains 40+ linked FAQ items across multiple categories
- Responsive design compatible with mobile and desktop browsers

https://claude.ai/code/session_01ToyWa47MMMfte2kGrhTCNQ